### PR TITLE
bugfix: image default placeholder

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -19,6 +19,8 @@ const mapDispatchToProps = (dispatch) => ({
   onUnload: () => dispatch({ type: ITEM_PAGE_UNLOADED }),
 });
 
+export const DEFAULT_PLACEHOLDER_IMG = "/placeholder.png";
+
 class Item extends React.Component {
   componentWillMount() {
     this.props.onLoad(
@@ -50,7 +52,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || DEFAULT_PLACEHOLDER_IMG}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -19,6 +19,8 @@ const mapDispatchToProps = (dispatch) => ({
   onUnload: () => dispatch({ type: ITEM_PAGE_UNLOADED }),
 });
 
+const DEFAULT_PLACEHOLDER_IMG = "/placeholder.png";
+
 class Item extends React.Component {
   componentWillMount() {
     this.props.onLoad(
@@ -50,7 +52,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || DEFAULT_PLACEHOLDER_IMG}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import agent from "../agent";
 import { connect } from "react-redux";
 import { ITEM_FAVORITED, ITEM_UNFAVORITED } from "../constants/actionTypes";
+import { DEFAULT_PLACEHOLDER_IMG } from "./Item";
 
 const mapDispatchToProps = (dispatch) => ({
   favorite: (slug) =>
@@ -36,7 +37,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || DEFAULT_PLACEHOLDER_IMG}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

This PR fix the bug on issue [2](https://github.com/ObelusFamily/Anythink-Market-lta4fxih/issues/2) by having a placeholder image when a user forgets to enter an image url for item being uploaded.

![Screenshot from 2022-11-08 21-10-27](https://user-images.githubusercontent.com/340843/201071143-632a6c23-ec76-4ee4-8f9a-583da1d7794f.png)
